### PR TITLE
Fix dataset upload duplication

### DIFF
--- a/pages/Configurations.py
+++ b/pages/Configurations.py
@@ -122,8 +122,10 @@ else:
         os.makedirs(datasets_folder)
 
     # 2) Initialize our session_state buckets (only happens once)
-    if "last_uploaded_file_id" not in st.session_state:
-        st.session_state["last_uploaded_file_id"] = None
+    if "last_uploaded_file_name" not in st.session_state:
+        st.session_state["last_uploaded_file_name"] = None
+    if "last_uploaded_file_size" not in st.session_state:
+        st.session_state["last_uploaded_file_size"] = None
 
     if "uploaded_dataset_names" not in st.session_state:
         # This will hold the list of folder‐names we've actually created
@@ -139,8 +141,11 @@ else:
 
     # 4) If the user has picked a new ZIP (filename changed), extract it once
     if uploaded_file is not None:
+        current_name = uploaded_file.name
+        current_size = uploaded_file.size
         # Check if this is actually a *new* upload (so we don't re-extract on every rerun)
-        if id(uploaded_file) != st.session_state["last_uploaded_file_id"]:
+        if (current_name != st.session_state["last_uploaded_file_name"] or
+                current_size != st.session_state["last_uploaded_file_size"]):
             # Start extraction
             status = st.empty()
             with st.spinner("Uploading and extracting…"):
@@ -165,7 +170,8 @@ else:
                 status.empty()
 
             # Remember that we extracted this one, and record the created folder-name
-            st.session_state["last_uploaded_file_id"] = id(uploaded_file)
+            st.session_state["last_uploaded_file_name"] = current_name
+            st.session_state["last_uploaded_file_size"] = current_size
             st.session_state["uploaded_dataset_names"].append(dataset_name)
         # else: same file as last time, so skip re-extraction
 


### PR DESCRIPTION
## Summary
- prevent dataset extraction from re-running unless a new file is uploaded

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68406634ad088322bde2faa121bde4bf