### PR TITLE
Fix dataset upload notifications

### DIFF
--- a/pages/Configurations.py
+++ b/pages/Configurations.py
@@ -126,9 +126,9 @@ else:
         # Track which uploaded files we've already extracted in this session
         st.session_state["processed_file_ids"] = set()
 
-    if "uploaded_dataset_names" not in st.session_state:
-        # This will hold the list of folder‐names we've actually created
-        st.session_state["uploaded_dataset_names"] = []
+    if "uploaded_dataset_name" not in st.session_state:
+        # This will hold the most recently uploaded folder-name
+        st.session_state["uploaded_dataset_name"] = None
 
     # 3) File uploader (always visible)
     st.markdown("##### Add Dataset (optional)")
@@ -171,11 +171,13 @@ else:
 
             # Remember that we extracted this one, and record the created folder-name
             st.session_state["processed_file_ids"].add(file_id)
-            st.session_state["uploaded_dataset_names"].append(dataset_name)
+            # Record only the latest uploaded dataset so previous
+            # notifications can be cleared on subsequent uploads
+            st.session_state["uploaded_dataset_name"] = dataset_name
 
-    # 5) Show a persistent notification for **every** zip‐to‐folder we've done so far
-    for name in st.session_state["uploaded_dataset_names"]:
-        st.success(f"Added new dataset: {name}")
+    # 5) Show a persistent notification for the most recently uploaded dataset
+    if st.session_state.get("uploaded_dataset_name"):
+        st.success(f"Added new dataset: {st.session_state['uploaded_dataset_name']}")
 
     # 6) Now list all folders under "../datasets" (including ones you uploaded previously,
     #    plus any that already existed on disk before you ran this app).


### PR DESCRIPTION
## Summary
- in Configurations, store only the most recent uploaded dataset
- display a single upload notification rather than one per dataset

## Testing
- `python -m py_compile pages/Configurations.py`

------
https://chatgpt.com/codex/tasks/task_e_68406f45966c83228134c9fbcfa4eac1