### PR TITLE
Fix quality-based folding warning by installing Matplotlib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -37,3 +37,4 @@ tzdata==2025.2
 urllib3==2.4.0
 watchdog==6.0.0
 streamlit-swipecards==0.2.0
+matplotlib==3.8.4


### PR DESCRIPTION
## Summary
- fix `Unable to import Axes3D` warning by adding Matplotlib to dependencies

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6887357a1db0832292a9531087d97da9