### PR TITLE
Ensure dataset configured on all pages

### DIFF
--- a/pages/DomainBasedFolding.py
+++ b/pages/DomainBasedFolding.py
@@ -41,14 +41,24 @@ with st.sidebar:
     st.page_link("pages/Results.py", label="Results")
 
 # 🔄 Load dataset from pipeline config if not already in session_state
+# Load the dataset from the pipeline configuration if available
 if "dataset_select" not in st.session_state and "pipeline_path" in st.session_state:
     config_path = os.path.join(st.session_state.pipeline_path, "configurations.json")
     if os.path.exists(config_path):
         with open(config_path) as f:
             config = json.load(f)
-        st.session_state["dataset_select"] = config.get("selected_dataset", "Demo")
+        selected = config.get("selected_dataset")
+        if selected:
+            st.session_state["dataset_select"] = selected
 
-selected_dataset = st.session_state.get("dataset_select", "Demo")
+# If we still don't have a dataset configured, show a warning and redirect option
+if "dataset_select" not in st.session_state:
+    st.warning("⚠️ Dataset not configured.")
+    if st.button("Go back to Configurations"):
+        st.switch_page("pages/Configurations.py")
+    st.stop()
+
+selected_dataset = st.session_state.dataset_select
 # Use absolute path for datasets
 root_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 datasets_path = os.path.join(root_dir, "datasets", selected_dataset)

--- a/pages/ErrorDetection.py
+++ b/pages/ErrorDetection.py
@@ -27,24 +27,26 @@ with st.sidebar:
     st.page_link("pages/ErrorDetection.py", label="Error Detection")
     st.page_link("pages/Results.py", label="Results")
 
-# Load configuration and dataset path
-if "pipeline_path" not in st.session_state:
-    st.error("No pipeline selected!")
+# ---------------------------------------------------------------------------
+# Determine the selected dataset, loading from the pipeline configuration if
+# available. Warn the user if no dataset is configured.
+# ---------------------------------------------------------------------------
+if "dataset_select" not in st.session_state and "pipeline_path" in st.session_state:
+    cfg_path = os.path.join(st.session_state.pipeline_path, "configurations.json")
+    if os.path.exists(cfg_path):
+        with open(cfg_path) as f:
+            cfg = json.load(f)
+        selected = cfg.get("selected_dataset")
+        if selected:
+            st.session_state.dataset_select = selected
+
+if "dataset_select" not in st.session_state:
+    st.warning("⚠️ Dataset not configured.")
+    if st.button("Go back to Configurations"):
+        st.switch_page("pages/Configurations.py")
     st.stop()
 
-config_path = os.path.join(st.session_state.pipeline_path, "configurations.json")
-if not os.path.exists(config_path):
-    st.error("Configuration file not found!")
-    st.stop()
-
-with open(config_path) as f:
-    config = json.load(f)
-
-selected_dataset = config.get("selected_dataset")
-if not selected_dataset:
-    st.error("No dataset selected!")
-    st.stop()
-
+selected_dataset = st.session_state.dataset_select
 datasets_path = os.path.join(os.path.dirname(__file__), "../datasets", selected_dataset)
 
 # Function to load and display table with propagated errors

--- a/pages/Labeling.py
+++ b/pages/Labeling.py
@@ -29,15 +29,21 @@ with st.sidebar:
     st.page_link("pages/Results.py", label="Results")
 
 # Load dataset from pipeline config if not already in session_state
+# Load dataset from pipeline configuration if available
 if "dataset_select" not in st.session_state and "pipeline_path" in st.session_state:
     cfg_path = os.path.join(st.session_state.pipeline_path, "configurations.json")
     if os.path.exists(cfg_path):
         with open(cfg_path) as f:
             cfg = json.load(f)
-        st.session_state.dataset_select = cfg.get("selected_dataset")
+        selected = cfg.get("selected_dataset")
+        if selected:
+            st.session_state.dataset_select = selected
 
+# If dataset remains undefined, warn user and provide a navigation button
 if "dataset_select" not in st.session_state:
-    st.warning("⚠️ Please configure a dataset first.")
+    st.warning("⚠️ Dataset not configured.")
+    if st.button("Go back to Configurations"):
+        st.switch_page("pages/Configurations.py")
     st.stop()
 
 dataset = st.session_state.dataset_select

--- a/pages/PropagatedErrors.py
+++ b/pages/PropagatedErrors.py
@@ -20,10 +20,37 @@ with st.sidebar:
     st.page_link("pages/ErrorDetection.py", label="Error Detection")
     st.page_link("pages/Results.py", label="Results")
 
+# Title
 st.title("Propagated Errors")
 
+# ---------------------------------------------------------------------------
+# Ensure dataset is configured before checking propagation results
+# ---------------------------------------------------------------------------
+# Attempt to load dataset from pipeline configuration if needed
+if "dataset_select" not in st.session_state and "pipeline_path" in st.session_state:
+    cfg_path = os.path.join(st.session_state.pipeline_path, "configurations.json")
+    if os.path.exists(cfg_path):
+        with open(cfg_path) as f:
+            cfg = json.load(f)
+        selected = cfg.get("selected_dataset")
+        if selected:
+            st.session_state.dataset_select = selected
+
+# If no dataset is available, direct the user back to Configurations
+if "dataset_select" not in st.session_state:
+    st.warning("⚠️ Dataset not configured.")
+    if st.button("Go back to Configurations"):
+        st.switch_page("pages/Configurations.py")
+    st.stop()
+
+# ---------------------------------------------------------------------------
+# If dataset is configured but no propagation results exist, guide user back to
+# labeling instead of showing an error
+# ---------------------------------------------------------------------------
 if "propagation_results" not in st.session_state:
-    st.error("No propagation results available. Please run labeling first.")
+    st.warning("No propagation results available. Please label the provided cells")
+    if st.button("Go back to Labeling"):
+        st.switch_page("pages/Labeling.py")
     st.stop()
 
 propagation_results = st.session_state.propagation_results

--- a/pages/QualityBasedFolding.py
+++ b/pages/QualityBasedFolding.py
@@ -64,15 +64,21 @@ with st.sidebar:
     st.page_link("pages/Results.py", label="Results")
 
 # Load selected dataset
+# Load selected dataset from pipeline configuration if available
 if "dataset_select" not in st.session_state and "pipeline_path" in st.session_state:
     cfg_path = os.path.join(st.session_state.pipeline_path, "configurations.json")
     if os.path.exists(cfg_path):
         with open(cfg_path) as f:
             cfg = json.load(f)
-        st.session_state.dataset_select = cfg.get("selected_dataset")
+        selected = cfg.get("selected_dataset")
+        if selected:
+            st.session_state.dataset_select = selected
 
+# If dataset is still not configured, inform the user and provide navigation
 if "dataset_select" not in st.session_state:
-    st.warning("⚠️ Please configure a dataset first.")
+    st.warning("⚠️ Dataset not configured.")
+    if st.button("Go back to Configurations"):
+        st.switch_page("pages/Configurations.py")
     st.stop()
 
 # Paths

--- a/pages/Results.py
+++ b/pages/Results.py
@@ -57,12 +57,6 @@ else:
     st.stop()
 
 col1, col2, col3 = st.columns(3)
-with col1:
-    st.metric(label="Recall", value=f"{recall_score:.2f}")
-with col2:
-    st.metric(label="F1 Score", value=f"{f1_score:.2f}")
-with col3:
-    st.metric(label="Precision", value=f"{precision_score:.2f}")
 
 # -----------------------------------------------------------------------------
 # Ensure that the current dataset is defined in session state.
@@ -74,78 +68,91 @@ if not current_dataset and "pipeline_path" in st.session_state:
     if current_dataset:
         st.session_state.dataset_select = current_dataset
 
-if not current_dataset:
-    st.warning("No dataset defined in session state.")
-    st.stop()
+dataset_configured = current_dataset is not None
+
+if dataset_configured:
+    with col1:
+        st.metric(label="Recall", value=f"{recall_score:.2f}")
+    with col2:
+        st.metric(label="F1 Score", value=f"{f1_score:.2f}")
+    with col3:
+        st.metric(label="Precision", value=f"{precision_score:.2f}")
+else:
+    with col1:
+        st.warning("⚠️ Dataset not configured.")
+        if st.button("Go back to Configurations"):
+            st.switch_page("pages/Configurations.py")
+    col2.empty()
+    col3.empty()
 
 current_pipeline_name = os.path.basename(current_pipeline_path)
 pipelines_folder = os.path.join(os.path.dirname(__file__), "../pipelines")
 
-same_dataset_rows = []
-for pipeline in os.listdir(pipelines_folder):
-    pipeline_dir = os.path.join(pipelines_folder, pipeline)
-    if os.path.isdir(pipeline_dir):
-        cfg = load_config(os.path.join(pipeline_dir, "configurations.json"))
-        if cfg.get("selected_dataset") == current_dataset:
-            labeling_budget = cfg.get("labeling_budget", "")
-            results_list = cfg.get("results", [])
-            for res in results_list:
-                metrics = res.get("metrics", {})
-                row = {
-                    "Time": res.get("Time", ""),
-                    "Pipeline Name": pipeline,
-                    "Labeling Budget": labeling_budget,
-                    "Recall": metrics.get("Recall", ""),
-                    "F1": metrics.get("F1", ""),
-                    "Precision": metrics.get("Precision", "")
-                }
-                same_dataset_rows.append(row)
+if dataset_configured:
+    same_dataset_rows = []
+    for pipeline in os.listdir(pipelines_folder):
+        pipeline_dir = os.path.join(pipelines_folder, pipeline)
+        if os.path.isdir(pipeline_dir):
+            cfg = load_config(os.path.join(pipeline_dir, "configurations.json"))
+            if cfg.get("selected_dataset") == current_dataset:
+                labeling_budget = cfg.get("labeling_budget", "")
+                results_list = cfg.get("results", [])
+                for res in results_list:
+                    metrics = res.get("metrics", {})
+                    row = {
+                        "Time": res.get("Time", ""),
+                        "Pipeline Name": pipeline,
+                        "Labeling Budget": labeling_budget,
+                        "Recall": metrics.get("Recall", ""),
+                        "F1": metrics.get("F1", ""),
+                        "Precision": metrics.get("Precision", "")
+                    }
+                    same_dataset_rows.append(row)
 
-found_current = any(
-    row["Pipeline Name"] == current_pipeline_name and row["Time"] == current_time
-    for row in same_dataset_rows
-)
-if not found_current:
-    current_cfg = load_config(os.path.join(current_pipeline_path, "configurations.json"))
-    current_labeling_budget = current_cfg.get("labeling_budget", "")
-    current_row = {
-        "Time": current_time,
-        "Pipeline Name": current_pipeline_name,
-        "Labeling Budget": current_labeling_budget,
-        "Recall": recall_score,
-        "F1": f1_score,
-        "Precision": precision_score
-    }
-    # Remove duplicates for today from same pipeline
-    same_dataset_rows = [
-        r for r in same_dataset_rows
-        if not (r["Pipeline Name"] == current_pipeline_name and r["Time"].split(" ")[0] == current_time.split(" ")[0])
-    ]
-    same_dataset_rows.append(current_row)
+    found_current = any(
+        row["Pipeline Name"] == current_pipeline_name and row["Time"] == current_time
+        for row in same_dataset_rows
+    )
+    if not found_current:
+        current_cfg = load_config(os.path.join(current_pipeline_path, "configurations.json"))
+        current_labeling_budget = current_cfg.get("labeling_budget", "")
+        current_row = {
+            "Time": current_time,
+            "Pipeline Name": current_pipeline_name,
+            "Labeling Budget": current_labeling_budget,
+            "Recall": recall_score,
+            "F1": f1_score,
+            "Precision": precision_score
+        }
+        same_dataset_rows = [
+            r for r in same_dataset_rows
+            if not (r["Pipeline Name"] == current_pipeline_name and r["Time"].split(" ")[0] == current_time.split(" ")[0])
+        ]
+        same_dataset_rows.append(current_row)
 
-same_dataset_df = pd.DataFrame(same_dataset_rows)
-for col in ["Recall", "F1", "Precision", "Labeling Budget"]:
-    if col in same_dataset_df.columns:
-        same_dataset_df[col] = pd.to_numeric(same_dataset_df[col], errors="coerce").round(2)
-same_dataset_df = same_dataset_df.sort_values(by="Time", ascending=False)
+    same_dataset_df = pd.DataFrame(same_dataset_rows)
+    for col in ["Recall", "F1", "Precision", "Labeling Budget"]:
+        if col in same_dataset_df.columns:
+            same_dataset_df[col] = pd.to_numeric(same_dataset_df[col], errors="coerce").round(2)
+    same_dataset_df = same_dataset_df.sort_values(by="Time", ascending=False)
 
-def highlight_current(row):
-    if row["Pipeline Name"] == current_pipeline_name and row["Time"] == current_time:
-        return ['background-color: red'] * len(row)
-    else:
-        return [''] * len(row)
+    def highlight_current(row):
+        if row["Pipeline Name"] == current_pipeline_name and row["Time"] == current_time:
+            return ['background-color: red'] * len(row)
+        else:
+            return [''] * len(row)
 
-styled_same_dataset_df = same_dataset_df.style.apply(highlight_current, axis=1).format({
-    "Recall": "{:.2f}",
-    "F1": "{:.2f}",
-    "Precision": "{:.2f}",
-    "Labeling Budget": "{:}"
-})
+    styled_same_dataset_df = same_dataset_df.style.apply(highlight_current, axis=1).format({
+        "Recall": "{:.2f}",
+        "F1": "{:.2f}",
+        "Precision": "{:.2f}",
+        "Labeling Budget": "{:}"
+    })
 
-st.markdown("---")
-st.markdown(f"#### Result Comparison (Dataset: {current_dataset}):")
-st.write("_(Click on column headers to sort the table.)_")
-st.dataframe(styled_same_dataset_df)
+    st.markdown("---")
+    st.markdown(f"#### Result Comparison (Dataset: {current_dataset}):")
+    st.write("_(Click on column headers to sort the table.)_")
+    st.dataframe(styled_same_dataset_df)
 
 # ---------------- ALL DATASETS ----------------
 all_rows = []
@@ -211,8 +218,8 @@ st.dataframe(styled_all_df)
 
 
 st.markdown("---")
-# Share Result button with additional share options
-if st.button("Share Result"):
+# Share Result button with additional share options (only if dataset is configured)
+if dataset_configured and st.button("Share Result"):
     share_text = (
         f"Check out my Matelda results! Recall: {recall_score:.2f}, "
         f"F1: {f1_score:.2f}, Precision: {precision_score:.2f}"


### PR DESCRIPTION
## Summary
- check dataset configuration first on Propagated Errors page and redirect to Labeling if results missing
- load dataset in Error Detection page before running detection
- show dataset warning on Results page when metrics can't be shown and hide Share Result button

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68878801c1108322a7ab527857b48637