### PR TITLE
Add real-time slider component for budget

### DIFF
--- a/components/__init__.py
+++ b/components/__init__.py
@@ -8,6 +8,7 @@ from .utils import (
     save_pipeline_config,
     update_domain_folds_in_config
 )
+from .realtime_slider import realtime_slider
 
 __all__ = [
     'render_sidebar',
@@ -17,5 +18,6 @@ __all__ = [
     'load_clean_table',
     'load_pipeline_config',
     'save_pipeline_config',
-    'update_domain_folds_in_config'
+    'update_domain_folds_in_config',
+    'realtime_slider'
 ]

--- a/components/realtime_slider/__init__.py
+++ b/components/realtime_slider/__init__.py
@@ -1,0 +1,17 @@
+import os
+import streamlit.components.v1 as components
+
+_component_func = components.declare_component(
+    "realtime_slider",
+    path=os.path.join(os.path.dirname(os.path.abspath(__file__)), "frontend"),
+)
+
+def realtime_slider(key: str, min_value: int = 0, max_value: int = 100, value: int = 0):
+    """A slider that updates in real time using Streamlit components."""
+    return _component_func(
+        key=key,
+        default=value,
+        min_value=min_value,
+        max_value=max_value,
+        value=value,
+    )

--- a/components/realtime_slider/frontend/index.html
+++ b/components/realtime_slider/frontend/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <script src="https://unpkg.com/streamlit-component-lib@1.2.1/dist/index.js"></script>
+  </head>
+  <body>
+    <input id="slider" type="range" />
+    <script>
+      const slider = document.getElementById("slider");
+      slider.oninput = (e) => Streamlit.setComponentValue(parseFloat(e.target.value));
+
+      const render = (event) => {
+        const args = event.detail.args;
+        slider.min = args.min_value;
+        slider.max = args.max_value;
+        slider.value = args.value;
+        Streamlit.setFrameHeight(40);
+      };
+
+      Streamlit.events.addEventListener(Streamlit.RENDER_EVENT, render);
+      Streamlit.setComponentReady();
+    </script>
+  </body>
+</html>

--- a/pages/Configurations.py
+++ b/pages/Configurations.py
@@ -4,7 +4,14 @@ import json
 import pandas as pd
 import zipfile
 import shutil
-from components import render_sidebar, apply_base_styles, get_datasets_path, load_pipeline_config, save_pipeline_config
+from components import (
+    render_sidebar,
+    apply_base_styles,
+    get_datasets_path,
+    load_pipeline_config,
+    save_pipeline_config,
+    realtime_slider,
+)
 
 # Set page config and apply base styles
 st.set_page_config(page_title="Configurations", layout="wide")
@@ -56,11 +63,6 @@ def load_pipeline_config_ui():
     st.session_state.preconfigured_dataset = pipeline_dataset
 
 
-def sync_slider_to_input():
-    """Keep the number input in sync when the slider changes."""
-    st.session_state.budget_input = st.session_state.budget_slider
-
-
 def sync_input_to_slider():
     """Keep the slider in sync when the number input changes."""
     st.session_state.budget_slider = st.session_state.budget_input
@@ -93,14 +95,16 @@ if pipeline_choice == "Use Existing Pipeline":
     col_slider, col_input = st.columns([3, 1])
 
     with col_slider:
-        st.slider(
-            "Select Labeling Budget:",
+        st.markdown("Select Labeling Budget:")
+        slider_val = realtime_slider(
+            key="budget_slider",
             min_value=1,
             max_value=100,
-            key="budget_slider",
-            label_visibility="visible",
-            on_change=sync_slider_to_input,
+            value=st.session_state.budget_slider,
         )
+        if slider_val is not None:
+            st.session_state.budget_slider = slider_val
+            st.session_state.budget_input = slider_val
 
     with col_input:
         st.number_input(
@@ -235,14 +239,16 @@ else:
     col_slider, col_input = st.columns([3, 1])
 
     with col_slider:
-        st.slider(
-            "Select Labeling Budget:",
+        st.markdown("Select Labeling Budget:")
+        slider_val = realtime_slider(
+            key="budget_slider",
             min_value=1,
             max_value=100,
-            key="budget_slider",
-            label_visibility="visible",
-            on_change=sync_slider_to_input,
+            value=st.session_state.budget_slider,
         )
+        if slider_val is not None:
+            st.session_state.budget_slider = slider_val
+            st.session_state.budget_input = slider_val
 
     with col_input:
         st.number_input(


### PR DESCRIPTION
## Summary
- Build a `realtime_slider` Streamlit component with an HTML range input that reports its value on each move.
- Expose `realtime_slider` through the components package for reuse.
- Replace budget `st.slider` in `Configurations` with the new real-time slider, syncing it with the existing number input.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688cee97cbbc83228970c4b39f7d0663